### PR TITLE
Add link to open wikipedia links

### DIFF
--- a/app/src/main/java/com/xpaulnim/nearby/MapsFragment.kt
+++ b/app/src/main/java/com/xpaulnim/nearby/MapsFragment.kt
@@ -2,8 +2,10 @@ package com.xpaulnim.nearby
 
 import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Location
+import android.net.Uri
 import android.os.Bundle
 import android.text.TextPaint
 import android.text.TextUtils
@@ -275,6 +277,10 @@ class MapsFragment : Fragment(R.layout.map_fragment) {
                     } else {
                         val pageTitle = response.query.pages[0].title
                         binding.titleTextView.text = pageTitle
+                        binding.readMoreTextView.setOnClickListener{
+                            val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse("${WIKIPEDIA_URL}/w/index.php?curid=$pageId"))
+                            startActivity(browserIntent)
+                        }
 
                         val pageSummary = response.query.pages[0].extract
                         if (pageSummary != null) {

--- a/app/src/main/java/com/xpaulnim/nearby/network/NearbyService.kt
+++ b/app/src/main/java/com/xpaulnim/nearby/network/NearbyService.kt
@@ -10,7 +10,7 @@ import okhttp3.logging.HttpLoggingInterceptor.Level
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
-private const val WIKIPEDIA_URL = "https://wikipedia.org/"
+const val WIKIPEDIA_URL = "https://wikipedia.org"
 private const val PREFERRED_THUMB_SIZE = 320
 
 // https://www.mediawiki.org/wiki/Wikimedia_Apps/iOS_FAQ

--- a/app/src/main/res/layout/map_fragment.xml
+++ b/app/src/main/res/layout/map_fragment.xml
@@ -94,7 +94,7 @@
                     android:textAppearance="?attr/textAppearanceBody2"
                     android:textColor="?android:attr/textColorSecondary" />
 
-                <TextView
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/readMoreTextView"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
Opening desktop link in browser for simplicity. Intent link is broken, see https://phabricator.wikimedia.org/T335651

Sort of fix for #3, bug will remain open until proper fix is implemented